### PR TITLE
Fix badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![CodeQL Advanced Python scan](https://github.com/AKHQProduction/delivery_service/actions/workflows/codeql.yml/badge.svg)](https://github.com/AKHQProduction/delivery_service/actions/workflows/codeql.yml)
-[![Pyright Type Check](https://github.com/AKHQProduction/delivery_service/actions/workflows/pyright.yml/badge.svg)](https://github.com/AKHQProduction/delivery_service/actions/workflows/pyright.yml)
-[![Tests](https://github.com/AKHQProduction/delivery_service/actions/workflows/tests.yml/badge.svg)](https://github.com/AKHQProduction/delivery_service/actions/workflows/tests.yml)
+[![Pyright and Pytest](https://github.com/AKHQProduction/delivery_service/actions/workflows/pytest.yml/badge.svg)](https://github.com/AKHQProduction/delivery_service/actions/workflows/pytest.yml)
 
 
 # Event storming


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change consolidates the Pyright type check and tests badges into a single badge for both Pyright and Pytest.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L2-R2): Replaced separate badges for Pyright Type Check and Tests with a single badge for Pyright and Pytest.